### PR TITLE
Support Session ID From Initializer

### DIFF
--- a/lib/magento/xml_api.rb
+++ b/lib/magento/xml_api.rb
@@ -29,6 +29,7 @@ module Magento
       @timeout = options[:timeout] || 60
       @proxy = options[:proxy] || nil 
       @debug = options[:debug] || false
+      @session_id = options[:session_id] || nil
     end
     
     def call(method, *arguments)


### PR DESCRIPTION
Added support to pass in the session id from the initializer options in order to prevent logins on every instantiation.

Currently, in our mobile app API, we instantiate this class fresh each request to certain endpoints which in turn causes a login request to magento every time which can cause horrible performance during spikes.

Signed-off-by: RJ Garcia <rj@stadiumgoods.com>